### PR TITLE
Fix pollRequest TypeError: Cannot read property 'length' of undefined

### DIFF
--- a/src/skypeweb.coffee
+++ b/src/skypeweb.coffee
@@ -287,6 +287,12 @@ class SkypeWebAdapter extends Adapter
           try
             if body.trim()
               body = JSON.parse body
+
+              if 0 == Object.keys(body).length
+                throw new Error "empty response"
+              else if body.errorCode?
+                throw new Error body.message
+
               self.onEventMessage msg for msg in body.eventMessages
           catch err
             self.robot.logger.error 'Parsing poll results failed: ' + err


### PR DESCRIPTION
Hi @sdimkov 

This PR is the error handling of the response of `pollRequest`
- `body` is an empty object
- contains `errorCode` in `body`

Before:

```
[Tue Sep 01 2015 02:21:18 GMT+0900 (JST)] ERROR Parsing poll results failed: TypeError: Cannot read property 'length' of undefined
```

After:

```
[Tue Sep 01 2015 20:42:12 GMT+0900 (JST)] ERROR Parsing poll results failed: Error: empty response
[Tue Sep 01 2015 20:13:17 GMT+0900 (JST)] ERROR Parsing poll results failed: Error: You must create an endpoint before performing this operation.
```
