### PR TITLE
Removed redundant doc text for sendInQueue method.

### DIFF
--- a/src/skypeweb.coffee
+++ b/src/skypeweb.coffee
@@ -211,7 +211,7 @@ class SkypeWebAdapter extends Adapter
   # @private
   # Store skype message to be send in queues
   #
-  # @note This prevents this prevents newer messages to be received prior
+  # @note This prevents newer messages from being received prior
   #   to older ones due to the async nature of the requests being made
   #
   # @param user [String] the recipient of the message


### PR DESCRIPTION
Disclaimer: this is _really_ trivial.

But I noticed some small typos in the documentation text for this method. This PR should help clear things up a bit.
