### PR TITLE
Update the hostname used to connect to Skype Web's new backend

### DIFF
--- a/src/skypeweb.coffee
+++ b/src/skypeweb.coffee
@@ -14,7 +14,7 @@ class SkypeWebAdapter extends Adapter
   constructor: (@robot) ->
     super @robot
 
-    url       = "https://client-s.gateway.messenger.live.com"
+    url       = "https://bay-client-s.gateway.messenger.live.com"
     @pollUrl  = "#{url}/v1/users/ME/endpoints/SELF/subscriptions/0/poll"
     @sendUrl  = (user) -> "#{url}/v1/users/ME/conversations/#{user}/messages"
     @sendBody = messagetype: 'RichText', contenttype: 'text', content: ''
@@ -163,7 +163,7 @@ class SkypeWebAdapter extends Adapter
       @headers[header.name] = header.value
     # Clear Content-Length as we won't bother setting correct value
     delete @headers['Content-Length']
-    @headers['Host'] = 'client-s.gateway.messenger.live.com'
+    @headers['Host'] = 'bay-client-s.gateway.messenger.live.com'
     @headers['Connection'] = 'keep-alive'
     @headers['Accept-Encoding'] = 'gzip, deflate'
     self = @


### PR DESCRIPTION
This morning I noticed that my Hubot instance was totally unable to establish a connection to Skype. Upon loading Skype Web in the browser and using Chrome's Developer Tools I noticed that the polling requests were now being directed to "bay-client-s.gateway.messenger.live.com" instead of just "client-s.gateway.messenger.live.com". Updating this URL has resolved the issue for me so I figured I'd share this patch.

I admit that this is not a very sustainable or elegant fix and will try to work on resolving the hostname in a more automated fashion, but in the meantime I needed to get my bot back online.
