### PR TITLE
Add missing package dependency for url-parse library

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "phantom": "~0.7.2",
     "request": "~2.58.0",
-    "escape-html": "~1.0.2"
+    "escape-html": "~1.0.2",
+    "url-parse": "~1.0.4"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I tried running the latest fix that you pushed for #5 but node complained that it could not resolve the new library that you referenced. Updating the package.json file to include a reference to this library resolved the issue for me.
