### PR TITLE
Update user agent version

### DIFF
--- a/src/skypeweb.coffee
+++ b/src/skypeweb.coffee
@@ -136,8 +136,8 @@ class SkypeWebAdapter extends Adapter
             self.robot.logger.debug 'Skype during login: ' + request.url
         # Use sane user-agent
         page.set 'settings.userAgent',
-          'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 ' +
-          '(KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 ' +
+          '(KHTML, like Gecko) Chrome/46.0.2490.86 Safari/537.36'
         # Login to skype web
         page.open 'https://web.skype.com', (status) ->
           setTimeout (->


### PR DESCRIPTION
Today I encountered a recurring issue: "ERROR SkypeWeb adapter failed to login!".

I then decided to make phantomjs take a screenshot on error to see what's wrong, and here it is :
![fail](https://cloud.githubusercontent.com/assets/1788218/11474887/e4d80fe4-977a-11e5-9a2f-bc24b4e849de.png)

So I simply tried to change the hardcoded user agent from Chrome 41 to Chrome 46, and my hubot connected again.
