### PR TITLE
Restores login to working order.

### DIFF
--- a/src/page_helper.coffee
+++ b/src/page_helper.coffee
@@ -34,7 +34,7 @@ class PageHelper
     @page.evaluate ((fields) ->
       for selector, value of fields
         document.querySelector(selector).value = value
-      document.querySelector("[type='submit']").click()
+      document.forms[0].submit()
     ), (->), fields
 
 

--- a/src/skypeweb.coffee
+++ b/src/skypeweb.coffee
@@ -154,14 +154,11 @@ class SkypeWebAdapter extends Adapter
         page.open 'https://web.skype.com', (status) ->
           helper = new PageHelper page
           helper.wait '#username', ->
-            if self.username.indexOf('@') is -1
-              helper.fillForm '#username': self.username, '#password': self.password
-            else  # login with a Windows Live account
-              # Submit username to trigger redirect
-              helper.fillForm '#username': self.username
-              # Wait a redirect to Windows Live login page
-              helper.wait 'input[type="submit"]', ->
-                helper.fillForm 'input[type="password"]': self.password
+            # Submit username to trigger redirect
+            helper.fillForm '#username': self.username
+            # Wait a redirect to Windows Live login page
+            helper.wait 'input[type="submit"]', ->
+              helper.fillForm 'input[type="password"]': self.password
     ), phantomOptions
 
 


### PR DESCRIPTION
Previous login logic would try to submit both the username and password at once, when they did not appear to be an email address. The latest version of the website expects just one field to be entered and then redirects to a form that contains both, after a short delay. Logic for handling this scenario already existed so we just use that by default. Unfortunately, the new submit button does not work with the `click()` method so we use `submit()`, instead.
